### PR TITLE
Use assertions instead of if clauses for errors

### DIFF
--- a/src/design.coffee
+++ b/src/design.coffee
@@ -74,10 +74,10 @@ class Design
   checkNamespace: (identifier, callback) ->
     { namespace, id } = Template.parseIdentifier(identifier)
 
-    if not namespace || @namespace == namespace
-      callback(id)
-    else
-      log.error("design #{ @namespace }: cannot get template with different namespace #{ namespace } ")
+    assert not namespace or @namespace is namespace,
+      "design #{ @namespace }: cannot get template with different namespace #{ namespace } "
+
+    callback(id)
 
 
   each: (callback) ->

--- a/src/document.coffee
+++ b/src/document.coffee
@@ -46,7 +46,7 @@ document = do ->
 
   # *Public API*
   init: ({ design, json, rootNode }={}) ->
-    log.error('document is already initialized') if @initialized
+    assert not @initialized, 'document is already initialized'
     @initialized = true
 
     @loadDesign(design)
@@ -138,8 +138,7 @@ document = do ->
   getTemplate: (identifier) ->
     template = @design?.get(identifier)
 
-    if !template
-      log.error("could not find template #{ identifier }")
+    assert template, "could not find template #{ identifier }"
 
     template
 

--- a/src/interface_injector.coffee
+++ b/src/interface_injector.coffee
@@ -1,9 +1,9 @@
 class InterfaceInjector
 
   constructor: ({ @snippet, @snippetContainer, @renderer }) ->
-
-    if @snippet && not @snippet.snippetView?.attachedToDom
-      log.error('snippet is not attached to the DOM')
+    if @snippet
+      assert @snippet.snippetView?.attachedToDom,
+        'snippet is not attached to the DOM'
 
     if @snippetContainer
       if not @snippetContainer.isRoot && not @snippetContainer.parentSnippet?.snippetView?.attachedToDom
@@ -11,27 +11,21 @@ class InterfaceInjector
 
 
   before: ($elem) ->
-    if @snippet
-      @beforeInjecting($elem)
-      @snippet.snippetView.$html.before($elem)
-    else
-      log.error('cannot use before on a snippetContainer')
+    assert @snippet, 'cannot use before on a snippetContainer'
+    @beforeInjecting($elem)
+    @snippet.snippetView.$html.before($elem)
 
 
   after: ($elem) ->
-    if @snippet
-      @beforeInjecting($elem)
-      @snippet.snippetView.$html.after($elem)
-    else
-      log.error('cannot use after on a snippetContainer')
+    assert @snippet, 'cannot use after on a snippetContainer'
+    @beforeInjecting($elem)
+    @snippet.snippetView.$html.after($elem)
 
 
   append: ($elem) ->
-    if @snippetContainer
-      @beforeInjecting($elem)
-      @renderer.appendToContainer(@snippetContainer, $elem)
-    else
-      log.error('cannot use append on a snippet')
+    assert @snippetContainer, 'cannot use append on a snippet'
+    @beforeInjecting($elem)
+    @renderer.appendToContainer(@snippetContainer, $elem)
 
 
   remove: () ->

--- a/src/kickstart.coffee
+++ b/src/kickstart.coffee
@@ -26,11 +26,10 @@ kickstart = do ->
 
   parseSnippets: (parentContainer, region, data) ->
     snippetName = @nodeToSnippetName(data)
-    if doc.document.design.get(snippetName)
-      snippet = doc.create(snippetName)
-      parentContainer.append(region, snippet)
-    else
-      log.error('The Template named "' + snippetName + '" does not exist.')
+    assert doc.document.design.get(snippetName),
+      "The Template named '#{snippetName}' does not exist."
+    snippet = doc.create(snippetName)
+    parentContainer.append(region, snippet)
     @setChildren(snippet, data)
 
 

--- a/src/page.coffee
+++ b/src/page.coffee
@@ -43,7 +43,7 @@ class Page
     else
       $root = $(rootNode).addClass(".#{ docClass.section }")
 
-    log.error('no rootNode found') if !$root.length
+    assert $root.length, 'no rootNode found'
     $root
 
 

--- a/src/renderer.coffee
+++ b/src/renderer.coffee
@@ -2,8 +2,8 @@ class Renderer
 
 
   constructor: ({ @snippetTree, rootNode, @page }) ->
-    log.error('no snippet tree specified') if !@snippetTree
-    log.error('no root node specified') if !rootNode
+    assert @snippetTree, 'no snippet tree specified'
+    assert rootNode, 'no root node specified'
 
     @$root = $(rootNode)
     @setupPageListeners()
@@ -99,7 +99,7 @@ class Renderer
   # in the SnippetTree
   insertIntoDom: (snippetView) ->
     snippetView.attach(this)
-    log.error('could not insert snippet into Dom') if not snippetView.attachedToDom
+    assert snippetView.attachedToDom, 'could not insert snippet into Dom'
     @afterDomInsert(snippetView)
 
     this

--- a/src/snippet_tree/snippet_container.coffee
+++ b/src/snippet_tree/snippet_container.coffee
@@ -27,8 +27,8 @@ class SnippetContainer
 
 
   append: (snippet) ->
-    if @parentSnippet? and snippet == @parentSnippet
-      log.error('cannot append snippet to itself')
+    if @parentSnippet
+      assert snippet isnt @parentSnippet, 'cannot append snippet to itself'
 
     if @last
       @insertAfter(@last, snippet)
@@ -40,7 +40,7 @@ class SnippetContainer
 
   insertBefore: (snippet, insertedSnippet) ->
     return if snippet.previous == insertedSnippet
-    log.error('cannot insert snippet before itself') if snippet == insertedSnippet
+    assert snippet isnt insertedSnippet, 'cannot insert snippet before itself'
 
     position =
       previous: snippet.previous
@@ -52,7 +52,7 @@ class SnippetContainer
 
   insertAfter: (snippet, insertedSnippet) ->
     return if snippet.next == insertedSnippet
-    log.error('cannot insert snippet after itself') if snippet == insertedSnippet
+    assert snippet isnt insertedSnippet, 'cannot insert snippet after itself'
 
     position =
       previous: snippet

--- a/src/snippet_tree/snippet_model.coffee
+++ b/src/snippet_tree/snippet_model.coffee
@@ -16,8 +16,7 @@ class SnippetModel
 
 
   constructor: ({ @template, id } = {}) ->
-    if !@template
-      log.error('cannot instantiate snippet without template reference')
+    assert @template, 'cannot instantiate snippet without template reference'
 
     @initializeContainers()
     @initializeEditables()
@@ -250,31 +249,27 @@ class SnippetModel
 SnippetModel.fromJson = (json, design) ->
   template = design.get(json.identifier)
 
-  if not template?
-    log.error("error while deserializing snippet: unknown template identifier '#{ json.identifier }'")
+  assert template,
+    "error while deserializing snippet: unknown template identifier '#{ json.identifier }'"
 
   model = new SnippetModel({ template, id: json.id })
   for editableName, value of json.editables
-    if model.editables.hasOwnProperty(editableName)
-      model.editables[editableName] = value
-    else
-      log.error("error while deserializing snippet: unknown editable #{ editableName }")
+    assert model.editables.hasOwnProperty(editableName),
+      "error while deserializing snippet: unknown editable #{ editableName }"
+    model.editables[editableName] = value
 
   for imageName, value of json.images
-    if model.images.hasOwnProperty(imageName)
-      model.images[imageName] = value
-    else
-      log.error("error while deserializing snippet: unknown image #{ imageName }")
+    assert model.images.hasOwnProperty(imageName),
+      "error while deserializing snippet: unknown image #{ imageName }"
+    model.images[imageName] = value
 
   for containerName, snippetArray of json.containers
-    if not model.containers.hasOwnProperty(containerName)
-      log.error("error while deserializing snippet: unknown container #{ containerName }")
+    assert model.containers.hasOwnProperty(containerName),
+      "error while deserializing snippet: unknown container #{ containerName }"
 
     if snippetArray
-
-      if not $.isArray(snippetArray)
-        log.error("error while deserializing snippet: container is not array #{ containerName }")
-
+      assert $.isArray(snippetArray),
+        "error while deserializing snippet: container is not array #{ containerName }"
       for child in snippetArray
         model.append( containerName, SnippetModel.fromJson(child, design) )
 

--- a/src/snippet_tree/snippet_tree.coffee
+++ b/src/snippet_tree/snippet_tree.coffee
@@ -171,15 +171,14 @@ class SnippetTree
 
 
   detachingSnippet: (snippet, detachSnippetFunc) ->
-    if snippet.snippetTree == this
+    assert snippet.snippetTree is this,
+      'cannot remove snippet from another SnippetTree'
 
-      snippet.descendantsAndSelf (descendants) ->
-        descendants.snippetTree = undefined
+    snippet.descendantsAndSelf (descendants) ->
+      descendants.snippetTree = undefined
 
-      detachSnippetFunc()
-      @fireEvent('snippetRemoved', snippet)
-    else
-      log.error('cannot remove snippet from another SnippetTree')
+    detachSnippetFunc()
+    @fireEvent('snippetRemoved', snippet)
 
 
   contentChanging: (snippet) ->

--- a/src/snippet_view.coffee
+++ b/src/snippet_view.coffee
@@ -66,17 +66,15 @@ class SnippetView
       value = editable
       editable = undefined
 
-    if elem = @getEditable(editable)
-      $(elem).html(value)
-    else
-      log.error 'cannot set value without editable name'
+    elem = @getEditable(editable)
+    assert elem, 'cannot set value without editable name'
+    $(elem).html(value)
 
 
   get: (editable) ->
-    if elem = @getEditable(editable)
-      $(elem).html()
-    else
-      log.error 'cannot get value without editable name'
+    elem = @getEditable(editable)
+    assert elem, 'cannot get value without editable name'
+    $(elem).html()
 
 
   append: (containerName, $elem) ->

--- a/src/template/snippet_node_list.coffee
+++ b/src/template/snippet_node_list.coffee
@@ -17,10 +17,8 @@ class SnippetNodeList
 
   # @api private
   assertNodeNameNotUsed: (node) ->
-    if @all[node.name]
-      log.error(
-        """
-        #{node.type} Template parsing error: #{ docAttr[node.type] }="#{ node.name }".
-        "#{ node.name }" is a duplicate name.
-        """
-      )
+    assert not @all[node.name],
+      """
+      #{node.type} Template parsing error: #{ docAttr[node.type] }="#{ node.name }".
+      "#{ node.name }" is a duplicate name.
+      """

--- a/src/template/template.coffee
+++ b/src/template/template.coffee
@@ -19,8 +19,7 @@ class Template
 
 
   constructor: ({ html, @namespace, @id, identifier, title, styles, weight, version } = {}) ->
-    if not html
-      log.error('Template: param html missing')
+    assert html, 'Template: param html missing'
 
     if identifier
       { @namespace, @id } = Template.parseIdentifier(identifier)

--- a/src/utils/assert.coffee
+++ b/src/utils/assert.coffee
@@ -1,0 +1,9 @@
+# Function to assert a condition. If the condition is not met, an error is
+# raised with the specified message.
+#
+# @example
+#
+#   assert a isnt b, 'a can not be b'
+#
+assert = (condition, message) ->
+  log.error(message) unless condition

--- a/src/utils/stash.coffee
+++ b/src/utils/stash.coffee
@@ -30,10 +30,8 @@ stash = do ->
   restore: ->
     json = @store.get()
 
-    if json
-      document.restore(json)
-    else
-      log.error('stash is empty')
+    assert json, 'stash is empty'
+    document.restore(json)
 
 
   list: ->


### PR DESCRIPTION
I noticed that log.error was being used in combination with if clauses
as a way of asserting preconditions. This commit introduces an assert
function that encapsulates this pattern. The code has less if clauses
and thus is easier to read.
