### PR TITLE
Comments in templates cause trouble in doc.kickstart

### DIFF
--- a/designs/bootstrap/design.js
+++ b/designs/bootstrap/design.js
@@ -3,7 +3,7 @@
     {
       "title": "Single Centered Column",
       "id": "column",
-      "html": "<div class=\"row-fluid\"><div class=\"span8 offset2\" doc-container=\"\"></div></div>"
+      "html": "<!-- test --><div class=\"row-fluid\"><div class=\"span8 offset2\" doc-container=\"\"></div></div>"
     },
     {
       "title": "Main and Sidebar Columns",

--- a/src/template/template.coffee
+++ b/src/template/template.coffee
@@ -28,7 +28,6 @@ class Template
       "#{ @namespace }.#{ @id }"
 
     @version = version || 1
-
     @$template = $( @pruneHtml(html) ).wrap('<div>')
     @$wrap = @$template.parent()
     @title = title || words.humanize( @id )
@@ -63,11 +62,16 @@ class Template
       images: list.image
 
 
-  # todo
   pruneHtml: (html) ->
-    # e.g. remove ids
-    html
 
+    # remove all comments
+    html = $(html).filter (index) ->
+      @nodeType !=8
+
+    # only allow one root element
+    assert html.length == 1, "Templates must contain one root element. The Template \"#{@identifier}\" contains #{ html.length }"
+
+    html
 
   # @param snippetNode: root DOM node of the snippet
   parseTemplate: () ->


### PR DESCRIPTION
The comment in the following template caused the date to be displayed twice in preview.html (the first time with its default value)

Even if we remove comments from templates in livingdocs-design the kickstart method should not be confused by them, if they are present in templates. (Or it should at least throw an error like 'invalid template')

``` html
<script type="ld-conf">
{
  "name": "Cover"
}
</script>

<!-- media/img/placeholderimg/bild_043.jpg -->
<div class="widget cover" style="background-image:url(http://placehold.it/1024x600/BEF56F/FFFFFF);">
        <div class="covertitle">
      <h3 class="uppertitle" doc-editable="uppertitle">Oberzeile</h3>
      <h2 class="maintitle" doc-editable="title">Titel</h2>
        </div>
</div>
```

preview.html

``` html
<cover>
  <uppertitle>Unesco-Welterbe</uppertitle>
  <title>Die Welt der Wunder wächst weiter</title>
</cover>
<date>16.10.2013</date>
<title>Die Welt der Wunder wächst weiter</title>
```
