### PR TITLE
publish events to observe snippet creation

### DIFF
--- a/src/api.coffee
+++ b/src/api.coffee
@@ -93,11 +93,6 @@ pageReady = ->
   # callback: (snippetModel) ->
   @snippetAdded = chainable(document.snippetTree.snippetAdded, 'add')
 
-  # Raised once the snippet tree has been built from json
-  # Uses the memory flag to trigger event once a subscriber has subscribed
-  # callback: (snippetModels) ->
-  @snippetsLoaded = chainable(document.snippetTree.snippetsLoaded, 'add')
-
   # Raised when a snippet is being dragged
   @startDrag = $.proxy(page, 'startDrag')
 

--- a/src/snippet_tree/snippet_tree.coffee
+++ b/src/snippet_tree/snippet_tree.coffee
@@ -30,9 +30,6 @@ class SnippetTree
   constructor: ({ content, design } = {}) ->
     @root = new SnippetContainer(isRoot: true)
 
-    # This event will fire with all the snippets built from the json
-    @snippetsLoaded = $.Callbacks('memory')
-
     # initialize content before we set the snippet tree to the root
     # otherwise all the events will be triggered while building the tree
     if content? and design?
@@ -233,12 +230,5 @@ class SnippetTree
       @root.append(snippet)
 
     @root.snippetTree = this
-    loadedSnippets = []
     @root.each (snippet) =>
       snippet.snippetTree = this
-      loadedSnippets.push(snippet)
-
-    @snippetsLoaded.fire(loadedSnippets)
-
-
-


### PR DESCRIPTION
The requirement for this pull-request was that I needed to be able to observe when a snippet was added to the page in order to replace some part of the instantiated snippets HTML with a custom template. In this scenario, there are 2 times when snippet addition becomes important:
1. when the page is first loaded from the persisted json representation
2. when snippets are added to the page during the editing process

At first the two events might look like one, but there is one important difference: when the snippetTree is assembled upon page creation there is no rendered representation available, i.e. there is no renderer.

There is a number of events already present on the snippetTree class. These only fire for editing operations, i.e. when the page is ready. This separation seems to make a lot of sense. So to expose an event for snippets added during editing, i.e. case (2), the snippetAdded event from the snippetTree is exposed.

In order to expose an event for case (1) I added a new event to the snippetTree class called snippetsLoaded. This event is fired only once when the page parsed a snippetTree from its json representation. The event can be used to retrieve the snippetModel instances that were loaded from the persistence layer. The event uses the memory flag on the jquery callbacks object since most of the time the code that will register for this event will only be around after the page was initially loaded, e.g. a UI element that wants to display information about the page loaded from the persistence layer will only be around once the page is created.

If the subscribing code needs the rendered page to be around it has the responsibility to only subscribe once this is given, i.e. subscribe only after doc.ready has fired. I thought about wiring this behavior right into the engine event, but this seems to be a too strong fit towards my specific use case and I might think of other cases that are happy only to get the snippetModels and don't care about the rendered page.

The two use cases above describe different points in time for the snippetTree. 

to observe the creation of snippets on the initial page loaded from json the snippetsLoaded event is exposed, to observe snippets added during editing the existing snippetAdded event of the snippetTree class is exposed in the API
