### PR TITLE
Bug: split done repeatedly copies content

### DIFF
--- a/src/editable_controller.coffee
+++ b/src/editable_controller.coffee
@@ -101,6 +101,12 @@ class EditableController
         cursor = Editable.createCursor(elem, if direction == 'before' then 'end' else 'beginning')
         cursor[ if direction == 'before' then 'insertAfter' else 'insertBefore' ](frag)
 
+        # Make sure the model of the mergedView is up to date
+        # otherwise bugs like in issue #56 can occur.
+        cursor.save()
+        @updateModel(mergedView, editableName)
+        cursor.restore()
+
         view.model.remove()
         cursor.setSelection()
 


### PR DESCRIPTION
Description:
Press Enter in the middle of a text passage. The block is split as expected. Press Backspace and the blocks are merged as expected with the cursor in the right position. Pressing Enter again now leaves all content in the first block intact and copies the content after the cursor to the new block.
