### PR TITLE
Encapsulate render node in Page

### DIFF
--- a/src/document.coffee
+++ b/src/document.coffee
@@ -61,15 +61,14 @@ document = do ->
       @changed.fire()
 
     # Page initialization
-    @page = new Page()
+    @page = new Page(rootNode)
 
     # load design assets into page
     if @design.css
       @page.loader.css(@design.css, doBeforeDocumentReady())
 
     # render document
-    rootNode ||= @page.getDocumentSection()[0]
-    @renderer = new Renderer(snippetTree: @snippetTree, rootNode: rootNode, page: @page)
+    @renderer = new Renderer(snippetTree: @snippetTree, page: @page)
 
     @ready.add =>
       @renderer.render()

--- a/src/page.coffee
+++ b/src/page.coffee
@@ -5,10 +5,11 @@ class Page
 
   LEFT_MOUSE_BUTTON = 1
 
-  constructor: ->
+  constructor: (renderNode) ->
     @document = window.document
     @$document = $(@document)
     @$body = $(@document.body)
+    @renderNode = renderNode || $(".#{ docClass.section }")[0]
 
     @loader = new Loader()
     @focus = new Focus()
@@ -41,18 +42,6 @@ class Page
   removeListeners: ->
     @$document.off('.livingdocs')
     @$document.off('.livingdocs-drag')
-
-
-  # @param rootNode (optional) DOM node that should contain the content
-  # @return jQuery object: the root node of the document
-  getDocumentSection: ({ rootNode } = {}) ->
-    if !rootNode
-      $root = $(".#{ docClass.section }").first()
-    else
-      $root = $(rootNode).addClass(".#{ docClass.section }")
-
-    assert $root.length, 'no rootNode found'
-    $root
 
 
   mousedown: (event) ->

--- a/src/renderer.coffee
+++ b/src/renderer.coffee
@@ -1,11 +1,12 @@
 class Renderer
 
 
-  constructor: ({ @snippetTree, rootNode, @page }) ->
+  constructor: ({ @snippetTree, @page }) ->
     assert @snippetTree, 'no snippet tree specified'
-    assert rootNode, 'no root node specified'
+    assert @page, 'no page specified'
+    assert @page.renderNode, 'page does not specify a node to render to'
 
-    @$root = $(rootNode)
+    @$root = $(@page.renderNode)
     @setupPageListeners()
     @setupSnippetTreeListeners()
     @snippets = {}

--- a/test/spec/mocks/page_mock.coffee
+++ b/test/spec/mocks/page_mock.coffee
@@ -1,5 +1,7 @@
 class PageMock
 
+  renderNode: $('<div/>')[0]
+
   focus:
 
     snippetFocus:

--- a/test/spec/renderer_spec.coffee
+++ b/test/spec/renderer_spec.coffee
@@ -2,8 +2,9 @@ describe 'renderer', ->
 
   beforeEach ->
     @tree = new SnippetTree()
-    @fragment = $('<div>')
-    @renderer = new Renderer(snippetTree: @tree, rootNode: @fragment, page: new PageMock())
+    page = new PageMock()
+    @fragment = $(page.renderNode)
+    @renderer = new Renderer(snippetTree: @tree, page: page)
 
 
   describe 'for a few snippets', ->


### PR DESCRIPTION
The page now has a property called renderNode which contains the node which
Renderer will use to render to. The renderNode can be specified during
initialization. If no node is specified, a node with the default CSS class
will searched for and used instead.

The Renderer now only takes a page and gets the renderNode from the Page that
is passed into the initializer. If the page does not specify a valid
renderNode at this point, an error is raised.
