### PR TITLE
Bug: Error in tests in Safari

### DIFF
--- a/src/utils/html_compare.coffee
+++ b/src/utils/html_compare.coffee
@@ -61,17 +61,36 @@ htmlCompare = do ->
 
 
   compareAttributes: (a, b) ->
-    if a.attributes.length == b.attributes.length
-      for attr in a.attributes
-        bValue = b.getAttribute(attr.name)
-        return false if not @compareAttributeValue(attr.name, attr.value, bValue)
+    @compareAttributesWithOther(a, b) &&
+    @compareAttributesWithOther(b, a)
 
-      return true
+
+  compareAttributesWithOther: (a, b) ->
+    for aAttr in a.attributes
+      bValue = b.getAttribute(aAttr.name)
+      return false if not @compareAttributeValue(aAttr.name, aAttr.value, bValue)
+
+      if  @isEmptyAttributeValue(aAttr.value) &&
+          @emptyAttributeCounts(aAttr.name)
+        return false if not b.hasAttribute(aAttr.name)
+
+    return true
+
+
+  emptyAttributeCounts: (attrName) ->
+    switch attrName
+      when 'class', 'style'
+        return false
+      else
+        return true
 
 
   compareAttributeValue: (attrName, aValue, bValue) ->
-    return true if not aValue? and not bValue?
-    return false if not aValue? or not bValue?
+    return true if  @isEmptyAttributeValue(aValue) &&
+                    @isEmptyAttributeValue(bValue)
+
+    return false if @isEmptyAttributeValue(aValue) ||
+                    @isEmptyAttributeValue(bValue)
 
     switch attrName
       when 'class'
@@ -84,6 +103,11 @@ htmlCompare = do ->
         aCleaned == bCleaned
       else
         aValue == bValue
+
+
+  # consider undefined, null and '' as empty
+  isEmptyAttributeValue: (val) ->
+    not val? || val == ''
 
 
   prepareStyleValue: (val) ->

--- a/test/spec/utils/html_compare_spec.coffee
+++ b/test/spec/utils/html_compare_spec.coffee
@@ -53,9 +53,21 @@ describe 'HtmlCompare', ->
       expect( compare(a, b) ).toBe(false)
 
 
-    it 'spots a missing attribute', ->
+    it 'spots a missing attribute in the first comparee', ->
+      a = $("<div></div>")[0]
+      b = $("<div id='b'></div>")[0]
+      expect( compare(a, b) ).toBe(false)
+
+
+    it 'spots a missing attribute in the second comparee', ->
       a = $("<div id='a'></div>")[0]
       b = $("<div></div>")[0]
+      expect( compare(a, b) ).toBe(false)
+
+
+    it 'spots a missing attribute with no value', ->
+      a = $("<div></div>")[0]
+      b = $("<div contenteditable></div>")[0]
       expect( compare(a, b) ).toBe(false)
 
 
@@ -73,6 +85,12 @@ describe 'HtmlCompare', ->
 
     it 'considers the same empty attributes equivalent', ->
       a = $("<div contenteditable></div>")[0]
+      b = $("<div contenteditable></div>")[0]
+      expect( compare(a, b) ).toBe(true)
+
+
+    it 'considers an empty attribute equal to one with no value', ->
+      a = $("<div contenteditable=''></div>")[0]
       b = $("<div contenteditable></div>")[0]
       expect( compare(a, b) ).toBe(true)
 
@@ -101,6 +119,12 @@ describe 'HtmlCompare', ->
       a = $("<div class='a b c'></div>")[0]
       b = $("<div class='a c'></div>")[0]
       expect( compare(a, b) ).toBe(false)
+
+
+    it 'treats empty class attribute as not existent', ->
+      a = $("<div></div>")[0]
+      b = $("<div class=''></div>")[0]
+      expect( compare(a, b) ).toBe(true)
 
 
   describe 'style attribute', ->
@@ -139,6 +163,12 @@ describe 'HtmlCompare', ->
       a = $("<div style='display:none; border: 1px solid #000'></div>")[0]
       b = $("<div style='display::none; border: 1px solid #000'></div>")[0]
       expect( compare(a, b) ).toBe(false)
+
+
+    it 'treats empty style attribute as not existent', ->
+      a = $("<div></div>")[0]
+      b = $("<div style=''></div>")[0]
+      expect( compare(a, b) ).toBe(true)
 
 
   describe 'text', ->


### PR DESCRIPTION
htmlCompare does not ignore an empty `style=''` attribute.
