### PR TITLE
Sort option on snippets & groups

### DIFF
--- a/src/design/design.coffee
+++ b/src/design/design.coffee
@@ -48,7 +48,7 @@ module.exports = class Design
       title: templateDefinition.title
       styles: templateStyles
       html: templateDefinition.html
-      weight: templateDefinition.sortOrder || 0
+      weight: templateDefinition.weight || 0
 
     @templates.push(template)
     template

--- a/test/support/test_design_json.coffee
+++ b/test/support/test_design_json.coffee
@@ -65,6 +65,7 @@ module.exports = do ->
   templates: [
       id:   'hero'
       title: 'Hero'
+      weight: 10
       styles: [
         name: 'Extra Space'
         type: 'option'
@@ -79,6 +80,7 @@ module.exports = do ->
         """
     ,
       id: 'title'
+      weight: 9
       title: 'Title'
       html: """<h1 #{ editableAttr }="title"></h1>"""
     ,


### PR DESCRIPTION
We should be able to define the order of snippets & groups.
In the engine we have a `sortOrder` property but it isn't used for sorting.
In the `livingdocs-design` project we already have the ability to define a `weight` on templates & groups.

One question that's still open is whether we want to sort the templates in the engine or in the livingdocs-design project.
IMO the sorting belongs to the engine. We also need more tests on this topic.
