### PR TITLE
Pass all directive configurations to the template directive

### DIFF
--- a/src/design/design_parser.coffee
+++ b/src/design/design_parser.coffee
@@ -83,8 +83,8 @@ module.exports = designParser =
     for name, conf of directives
       directive = component.directives.get(name)
       assert directive, "Could not find directive #{ name } in #{ component.name } component."
-      directiveConfig =
-        imageRatios: @lookupImageRatios(conf.imageRatios)
+      directiveConfig = $.extend({}, conf)
+      directiveConfig.imageRatios = @lookupImageRatios(conf.imageRatios) if conf.imageRatios
       directive.setConfig(directiveConfig)
 
 


### PR DESCRIPTION
Before, only the special imageRatios config was passed in.