### PR TITLE
EDITABLES_PLCAHOLDER: Added editables inputed text placholders support

### DIFF
--- a/src/component_tree/editable_directive.coffee
+++ b/src/component_tree/editable_directive.coffee
@@ -3,12 +3,30 @@ words = require('../modules/words')
 
 module.exports = class EditableDirective
 
+  placeholder = null
+  placeholderRegexp = null
+
+
   constructor: ({ @component, @templateDirective }) ->
     @name = @templateDirective.name
     @type = @templateDirective.type
 
+    if @templateDirective.inputPlaceholder
+      placeholder = @templateDirective.inputPlaceholder
+        .replace(/^\s+/, '&nbsp;')
+
+      prepared = placeholder
+        .replace(/[\-\[\]\/\{\}\(\)\*\+\?\.\\\^\$\|]/g, "\\$&")
+        .replace(' ', '\\s+')
+      placeholderRegexp = new RegExp('^(' + prepared + '|\\s*)$')
+
+      @hasPlaceholder = true
+
 
   isEditable: true
+
+
+  hasPlaceholder: false
 
 
   getContent: ->
@@ -23,4 +41,12 @@ module.exports = class EditableDirective
     content = @getContent()
     return '' unless content
     words.extractTextFromHtml(content)
+
+
+  getPlaceholder: ->
+    placeholder
+
+
+  isEmptyPlaceholder: (value) ->
+    placeholderRegexp.test(value)
 

--- a/src/configuration/config.coffee
+++ b/src/configuration/config.coffee
@@ -103,6 +103,10 @@ module.exports = augmentConfig(
       attr: 'doc-optional'
       renderedAttr: 'calculated later'
       elementDirective: false
+    inputPlaceholder:
+      attr: 'doc-input-placeholder'
+      renderedAttr: 'calculated later'
+      elementDirective: false
 
 
   animations:

--- a/src/interaction/editable_controller.coffee
+++ b/src/interaction/editable_controller.coffee
@@ -74,6 +74,10 @@ module.exports = class EditableController
 
     element = view.getDirectiveElement(editableName)
     @page.focus.editableFocused(element, view)
+
+    directive = view.model.directives.get(editableName)
+    @editable.prependTo(element, directive.getPlaceholder()) if directive.hasPlaceholder && !@extractContent(element)
+
     true # enable editable.js default behaviour
 
 
@@ -81,6 +85,10 @@ module.exports = class EditableController
     @clearChangeTimeout()
 
     element = view.getDirectiveElement(editableName)
+    directive = view.model.directives.get(editableName)
+    # Dirty spike because editable has no explicit method for text removing
+    element.innerHTML = '' if directive.hasPlaceholder && directive.isEmptyPlaceholder(@extractContent(element))
+
     @updateModel(view, editableName, element)
 
     view.blurEditable(editableName)

--- a/src/template/directive_compiler.coffee
+++ b/src/template/directive_compiler.coffee
@@ -44,6 +44,8 @@ module.exports = do ->
       switch directive.type
         when 'optional'
           mainDirective.optional = true
+        when 'inputPlaceholder'
+          mainDirective.inputPlaceholder = directive.name
 
 
   # Normalize or remove the attribute


### PR DESCRIPTION
 Purpose is to put default text when user places cursor into empty field (example: Place ' (Bild: )' text into image title to force users format text in proper way)