### PR TITLE
Render view updates per directive

### DIFF
--- a/src/component_tree/component_tree.coffee
+++ b/src/component_tree/component_tree.coffee
@@ -222,8 +222,8 @@ module.exports = class ComponentTree
     @fireEvent('componentRemoved', component)
 
 
-  contentChanging: (component) ->
-    @fireEvent('componentContentChanged', component)
+  contentChanging: (component, directiveName) ->
+    @fireEvent('componentContentChanged', component, directiveName)
 
 
   htmlChanging: (component) ->

--- a/src/rendering/component_view.coffee
+++ b/src/rendering/component_view.coffee
@@ -29,8 +29,11 @@ module.exports = class ComponentView
     @updateHtml()
 
 
-  updateContent: ->
-    @content(@model.content)
+  updateContent: (directiveName) ->
+    if directiveName
+      @set(directiveName, @model.content[directiveName])
+    else
+      @setAll()
 
     if not @hasFocus()
       @displayOptionals()
@@ -107,23 +110,24 @@ module.exports = class ComponentView
     dom.getAbsoluteBoundingClientRect(@$html[0])
 
 
-  content: (content) ->
-    for name, value of content
-      directive = @model.directives.get(name)
-      if directive.isImage
-        if directive.base64Image?
-          @set(name, directive.base64Image)
-        else
-          @set(name, directive.getImageUrl() )
-      else
-        @set(name, value)
+  # Set all directives at once
+  setAll: ->
+    for name, value of @model.content
+      @set(name, value)
+
+    undefined
 
 
   set: (name, value) ->
-    directive = @directives.get(name)
+    directive = @model.directives.get(name)
     switch directive.type
       when 'editable' then @setEditable(name, value)
-      when 'image' then @setImage(name, value)
+      when 'image'
+        if directive.base64Image?
+          @setImage(name, directive.base64Image)
+        else
+          @setImage(name, directive.getImageUrl() )
+
       when 'html' then @setHtml(name, value)
 
 
@@ -146,7 +150,6 @@ module.exports = class ComponentView
     $elem = @directives.$getElem(name)
     $elem.toggleClass(css.noPlaceholder, Boolean(value))
     $elem.attr(attr.placeholder, @template.defaults[name])
-
     $elem.html(value || '')
 
 

--- a/src/rendering/renderer.coffee
+++ b/src/rendering/renderer.coffee
@@ -100,8 +100,8 @@ module.exports = class Renderer
     @insertComponent(model)
 
 
-  componentContentChanged: (model) ->
-    @componentViewForComponent(model).updateContent()
+  componentContentChanged: (model, directiveName) ->
+    @componentViewForComponent(model).updateContent(directiveName)
 
 
   componentHtmlChanged: (model) ->

--- a/test/specs/rendering/component_view_spec.coffee
+++ b/test/specs/rendering/component_view_spec.coffee
@@ -137,8 +137,9 @@ describe 'ComponentView image', ->
 
 
     it 'sets the src', ->
+      @component.set('image', 'http://images.com/1')
       @view = @component.createView()
-      @view.set('image', 'http://images.com/1')
+      @view.updateContent('image')
       expectSrc(@view, 'http://images.com/1')
 
 
@@ -147,11 +148,12 @@ describe 'ComponentView image', ->
     it 'sets the data-src attribute', ->
       @view = @component.createView()
       @view.model.directives.get('image').setImageService('resrc.it')
-      @view.set('image', 'http://images.com/1')
+      @component.set('image', 'http://images.com/1')
+      @view.updateContent('image')
       expect(@view.$html).to.have.html """
         <img
           src=""
-          data-src="http://images.com/1"
+          data-src="https://app.resrc.it/O=75/http://images.com/1"
           class="#{ css.component } resrc"
           #{ test.imageAttr }="image"
           #{ attr.template }="test.image">
@@ -185,7 +187,8 @@ describe 'ComponentView image', ->
 
     it 'does not re-insert placeholders if value is set later on', ->
       imageUrl = 'http://www.bla.com'
-      @view.set('image', imageUrl)
+      @component.set('image', imageUrl)
+      @view.updateContent('image')
       @view.wasAttachedToDom.fireWith(@view.$html)
 
       expect(@view.$html).to.have.html """
@@ -196,10 +199,10 @@ describe 'ComponentView image', ->
 
 
     it 'remove the empty image css class when the image is set', ->
-      placeholderUrl = 'http://placehold.it/0x0/BEF56F/B2E668'
       imageUrl = 'http://www.bla.com'
       @view.wasAttachedToDom.fireWith(@view.$html)
-      @view.set('image', imageUrl)
+      @component.set('image', imageUrl)
+      @view.updateContent('image')
 
       expect(@view.$html).to.have.html """
         <img src="#{ imageUrl }"
@@ -217,8 +220,9 @@ describe 'ComponentView background image', ->
   describe 'with the default image service', ->
 
     it 'sets the background-image in the style attribute', ->
+      @component.set('image', 'http://images.com/1')
       @view = @component.createView()
-      @view.set('image', 'http://images.com/1')
+      @view.updateContent('image')
       expect(@view.$html).to.have.html """
         <div
           style="background-image: url(http://images.com/1);"

--- a/test/specs/rendering/component_view_spec.coffee
+++ b/test/specs/rendering/component_view_spec.coffee
@@ -9,41 +9,41 @@ describe 'component_view:', ->
   describe 'title', ->
 
     beforeEach ->
-      @componentView = test.getTemplate('title').createView()
+      @view = test.getTemplate('title').createView()
       @expected = $ """
         <h1 #{ test.editableAttr }="title"
           class="#{ css.editable } #{ css.component }"
             #{ attr.template }="test.title"
-            #{ attr.placeholder }="#{ @componentView.template.defaults['title'] }">
+            #{ attr.placeholder }="#{ @view.template.defaults['title'] }">
         </h1>
         """
 
 
     it 'sets title', ->
-      @componentView.set('title', 'Humble Bundle')
+      @view.set('title', 'Humble Bundle')
       @expected.addClass(css.noPlaceholder)
       @expected.html('Humble Bundle')
-      expect(@componentView.$html).to.have.html(@expected)
+      expect(@view.$html).to.have.html(@expected)
 
 
     describe 'when clearing an existing value', ->
       it 'clears the html', ->
-        @componentView.set('title', 'foobar')
-        @componentView.set('title', undefined)
-        expect(@componentView.$html[0]).to.have.html(@expected[0])
+        @view.set('title', 'foobar')
+        @view.set('title', undefined)
+        expect(@view.$html[0]).to.have.html(@expected[0])
 
 
     it 'renders content from the model', ->
-      @componentView.model.set('title', 'Humble Bundle')
-      @componentView.render()
+      @view.model.set('title', 'Humble Bundle')
+      @view.render()
       @expected.addClass(css.noPlaceholder)
       @expected.html('Humble Bundle')
-      expect(@componentView.$html).to.have.html(@expected)
+      expect(@view.$html).to.have.html(@expected)
 
 
     it 'gets the title', ->
-      @componentView.set('title', 'Games Galore')
-      expect( @componentView.get('title') ).to.equal('Games Galore')
+      @view.set('title', 'Games Galore')
+      expect( @view.get('title') ).to.equal('Games Galore')
 
 
 describe 'ComponentView title set style', ->
@@ -78,46 +78,46 @@ describe 'ComponentView hero', ->
     component.set('title', 'Humble Bundle 2')
     component.set('tagline', 'Get it now!')
     template = test.getTemplate('hero')
-    @componentView = template.createView(component)
+    @view = template.createView(component)
     @expected = $ """
       <div  class="#{ css.component }"
             #{ attr.template }="test.hero">
         <h1 #{ test.editableAttr }="title"
             class="#{ css.editable } #{ css.noPlaceholder }"
-            #{ attr.placeholder }="#{ @componentView.template.defaults['title'] }">Humble Bundle 2</h1>
+            #{ attr.placeholder }="#{ @view.template.defaults['title'] }">Humble Bundle 2</h1>
         <p  #{ test.editableAttr }="tagline"
             class="#{ css.editable } #{ css.noPlaceholder }"
-            #{ attr.placeholder }="#{ @componentView.template.defaults['tagline'] }">Get it now!</p>
+            #{ attr.placeholder }="#{ @view.template.defaults['tagline'] }">Get it now!</p>
       </div>"""
 
 
   it 'renders component content on creation', ->
-    expect(@componentView.$html).to.have.html(@expected)
+    expect(@view.$html).to.have.html(@expected)
 
 
   it 'sets "extra-space"', ->
     @expected.addClass('extra-space')
-    @componentView.setStyle('extra-space', 'extra-space')
-    expect(@componentView.$html).to.have.html(@expected)
+    @view.setStyle('extra-space', 'extra-space')
+    expect(@view.$html).to.have.html(@expected)
 
 
   it 'resets "extra-space"', ->
-    @componentView.setStyle('extra-space', 'extra-space')
-    @componentView.setStyle('extra-space', '')
-    expect(@componentView.$html).to.have.html(@expected)
+    @view.setStyle('extra-space', 'extra-space')
+    @view.setStyle('extra-space', '')
+    expect(@view.$html).to.have.html(@expected)
 
 
   describe 'empty optional', ->
 
     beforeEach ->
-      @componentView.model.set('tagline', undefined)
-      @componentView.render()
+      @view.model.set('tagline', undefined)
+      @view.render()
       @expected.find('p').hide().html('')
       @expected.find('p').removeClass(css.noPlaceholder)
 
 
     it 'is hidden by default', ->
-      expect(@componentView.$html).to.have.html(@expected)
+      expect(@view.$html).to.have.html(@expected)
 
 
 describe 'ComponentView image', ->

--- a/test/specs/rendering/component_view_spec.coffee
+++ b/test/specs/rendering/component_view_spec.coffee
@@ -107,6 +107,14 @@ describe 'ComponentView hero', ->
     expect(@view.$html).to.have.html(@expected)
 
 
+  it 'set(directiveName) does only update the passed directive', ->
+    @view.model.set('title', 'bla')
+    spy = sinon.spy(@view, 'set')
+    @view.updateContent('title')
+    expect(spy.callCount).to.equal(1)
+    expect(spy.firstCall.args[0]).to.equal('title')
+
+
   describe 'empty optional', ->
 
     beforeEach ->


### PR DESCRIPTION
Only replace the HTML of the directive that has changed.

If you have an image with a caption for example. Changing the caption will no longer re-insert the image and so no longer force the browser to repaint more than necessary.