### PR TITLE
reference counting in dependency manager does not work

### DIFF
--- a/src/rendering/dependencies.coffee
+++ b/src/rendering/dependencies.coffee
@@ -26,7 +26,7 @@ module.exports = class Dependencies
     @convertToAbsolutePaths(obj)
     dep = new Dependency(obj)
     if existing = @getExisting(dep)
-      existing.addComponent(component) if component?
+      existing.addComponent(obj.component) if obj.component?
     else
       @addDependency(dep)
 

--- a/test/specs/rendering/dependencies_spec.coffee
+++ b/test/specs/rendering/dependencies_spec.coffee
@@ -79,6 +79,17 @@ describe 'dependencies:', ->
       expect( @dependencies.hasJs() ).to.equal(false)
 
 
+    it 'does not remove a dependency if there is still another component with this dependency', ->
+      @secondComponent = @componentTree.createComponent('text')
+      @componentTree.append(@secondComponent)
+      for component in [@component, @secondComponent]
+        @dependencies.addJs
+          src: 'https://platform.twitter.com/widgets.js'
+          component: component
+      @component.remove() # remove only the first, second is still there
+      expect( @dependencies.hasJs() ).to.equal(true)
+
+
   describe 'deserialize()', ->
 
     beforeEach ->


### PR DESCRIPTION
When having a JS dependency on several components in an article, the JS dependency gets removed as soon as the first dependency is removed even if there are still components with this dependency in the article.