### PR TITLE
Dependencies that are added to a document get removed when a component is removed

### DIFF
--- a/src/rendering/dependency.coffee
+++ b/src/rendering/dependency.coffee
@@ -54,7 +54,9 @@ module.exports = class Dependency
       @componentCount -= 1
       @components[component.id] = undefined
 
-    @componentCount != 0
+      @componentCount != 0
+    else
+      true
 
 
   isSameAs: (otherDependency) ->


### PR DESCRIPTION
If you add a dependency to a document (not a component) it gets removed all the same when you remove a component of that type from the document.