### PR TITLE
container focus event

### DIFF
--- a/src/component_tree/component_model.coffee
+++ b/src/component_tree/component_model.coffee
@@ -169,7 +169,15 @@ module.exports = class ComponentModel
     @descendants(callback)
 
 
-  # return all descendant containers (including those of this componentModel)
+  # iterate over all parent containers (bubbling up)
+  parentContainers: (callback) ->
+    componentModel = this
+    while componentModel?
+      callback(componentModel.parentContainer)
+      componentModel = componentModel.getParent()
+
+
+  # iterate over all descendant containers (including those of this componentModel)
   descendantContainers: (callback) ->
     @descendantsAndSelf (componentModel) ->
       for name, componentContainer of componentModel.containers

--- a/src/interaction/container_event.coffee
+++ b/src/interaction/container_event.coffee
@@ -1,0 +1,7 @@
+module.exports = class ContainerEvent
+
+  constructor: ({ @target, focus, blur }) ->
+    @type = if focus
+      'containerFocus'
+    else if blur
+      'containerBlur'

--- a/src/interaction/focus.coffee
+++ b/src/interaction/focus.coffee
@@ -11,6 +11,8 @@ module.exports = class Focus
 
     @componentFocus = $.Callbacks()
     @componentBlur = $.Callbacks()
+    @containerFocus = $.Callbacks()
+    @containerBlur = $.Callbacks()
 
 
   setFocus: (componentView, editableNode) ->

--- a/src/interaction/focus.coffee
+++ b/src/interaction/focus.coffee
@@ -1,4 +1,5 @@
 dom = require('./dom')
+ContainerEvent = require('./container_event')
 
 # Component Focus
 # ---------------
@@ -25,7 +26,7 @@ module.exports = class Focus
       if componentView
         @componentView = componentView
         @componentFocus.fire(@componentView)
-        @bubbleUpEvent @componentView.model, target: @componentView, type: 'containerFocus'
+        @fireContainerEvent(view: @componentView, focus: true)
 
 
   # call after browser focus change
@@ -66,13 +67,12 @@ module.exports = class Focus
       previous = @componentView
       @componentView = undefined
       @componentBlur.fire(previous)
-      @bubbleUpEvent previous.model, target: previous, type: 'containerBlur'
+      @fireContainerEvent(view: previous, blur: true)
 
 
-  bubbleUpEvent: (component, event) ->
-    if component.parentContainer?
-      this[event.type].fire(component.parentContainer, event)
-      unless component.parentContainer.isRoot
-        @bubbleUpEvent(component.getParent(), event)
-
+  fireContainerEvent: ({ view, focus, blur }) ->
+    event = new ContainerEvent({ target: view, focus, blur })
+    component = view.model
+    component.parentContainers (container) =>
+      this[event.type].fire(container, event)
 

--- a/src/interaction/focus.coffee
+++ b/src/interaction/focus.coffee
@@ -25,6 +25,7 @@ module.exports = class Focus
       if componentView
         @componentView = componentView
         @componentFocus.fire(@componentView)
+        @bubbleUpEvent @componentView.model, target: @componentView, type: 'containerFocus'
 
 
   # call after browser focus change
@@ -65,5 +66,13 @@ module.exports = class Focus
       previous = @componentView
       @componentView = undefined
       @componentBlur.fire(previous)
+      @bubbleUpEvent previous.model, target: previous, type: 'containerBlur'
+
+
+  bubbleUpEvent: (component, event) ->
+    if component.parentContainer?
+      this[event.type].fire(component.parentContainer, event)
+      unless component.parentContainer.isRoot
+        @bubbleUpEvent(component.getParent(), event)
 
 


### PR DESCRIPTION
Currently, we know when a `componentView` has been focused through the `componentFocus` event. When a user selects a `componentView` in a container we don't know that the container was selected however.

The usecase for this issue is a gallery component which consists of a container that can contain images and embeds. When the user selects one of the images (or embeds) the context in the user interface should take into account the fact that we are in a gallery. We could listen for the `componentFocus` event and then on each `componentFocus` check if the container is a gallery. Doing this in the editor though feels wrong. It would be nicer to have a `containerFocus` event that the editor can subscribe to.

The proposed solution is to introduce the following event callback:
```
@page.focus.containerFocus.add (container, focusDepth) ->
```
The `focusDepth` parameter indicates on which child level the focus event happened, e.g., `1` means that a direct child was focused while `2` means that a child in a nested container was focused.

The root container is excluded from this event, i.e., the callback will never be called with the root container as a parameter.
