### PR TITLE
Basic support for editor plugins

### DIFF
--- a/src/component_tree/component_model.coffee
+++ b/src/component_tree/component_model.coffee
@@ -307,6 +307,18 @@ module.exports = class ComponentModel
     true
 
 
+  getPluginName: ->
+    @plugin?.name
+
+
+  setPlugin: (plugin) ->
+    @plugin = plugin
+
+
+  getPlugin: (plugin) ->
+    @plugin
+
+
   # Style Operations
   # ----------------
 

--- a/src/component_tree/component_model.coffee
+++ b/src/component_tree/component_model.coffee
@@ -133,7 +133,7 @@ module.exports = class ComponentModel
 
 
   # ComponentTree Iterators
-  # ---------------------
+  # -----------------------
   #
   # Navigate and query the componentTree relative to this component.
 
@@ -153,6 +153,11 @@ module.exports = class ComponentModel
       while (componentModel)
         callback(componentModel)
         componentModel = componentModel.next
+
+
+  childrenAndSelf: (callback) ->
+    callback(this)
+    @children(callback)
 
 
   descendants: (callback) ->
@@ -190,11 +195,6 @@ module.exports = class ComponentModel
       callback(componentModel) if componentModel != this
       for name, componentContainer of componentModel.containers
         callback(componentContainer)
-
-
-  childrenAndSelf: (callback) ->
-    callback(this)
-    @children(callback)
 
 
   # Directive Operations

--- a/src/component_tree/component_tree.coffee
+++ b/src/component_tree/component_tree.coffee
@@ -206,7 +206,7 @@ module.exports = class ComponentTree
 
 
   fireEvent: (event, args...) ->
-    this[event].fire.apply(event, args)
+    this[event].fire.apply(undefined, args)
     @changed.fire()
 
 

--- a/src/component_tree/component_tree.coffee
+++ b/src/component_tree/component_tree.coffee
@@ -148,10 +148,10 @@ module.exports = class ComponentTree
   # Note: There can be multiple views for a componentTree. With this
   # method we can set a main view so it becomes possible to get a view
   # directly from the componentTree for convenience
-  setMainView: (view) ->
-    assert view.renderer, 'componentTree.setMainView: view does not have an initialized renderer'
-    assert view.renderer.componentTree == this, 'componentTree.setMainView: Cannot set renderer from different componentTree'
-    @mainRenderer = view.renderer
+  setMainView: ({ renderer }) ->
+    assert renderer, 'componentTree.setMainView: view does not have an initialized renderer'
+    assert renderer.componentTree == this, 'componentTree.setMainView: Cannot set renderer from different componentTree'
+    @mainRenderer = renderer
 
 
   # Get the componentView for a model

--- a/src/modules/semaphore.coffee
+++ b/src/modules/semaphore.coffee
@@ -52,22 +52,22 @@ module.exports = class Semaphore
     @fireIfReady()
 
 
-  increment: ->
+  increment: (num = 1) ->
     assert not @wasFired,
       "Unable to increment count once Semaphore is fired."
-    @count += 1
+    @count += num
 
 
-  decrement: ->
+  decrement: (num = 1) ->
     assert @count > 0,
       "Unable to decrement count resulting in negative count."
-    @count -= 1
+    @count -= num
     @fireIfReady()
 
 
-  wait: ->
-    @increment()
-    => @decrement()
+  wait: (num) ->
+    @increment(num)
+    => @decrement(num)
 
 
   # @private

--- a/src/rendering/component_view.coffee
+++ b/src/rendering/component_view.coffee
@@ -9,6 +9,7 @@ dom = require('../interaction/dom')
 module.exports = class ComponentView
 
   constructor: ({ @model, @$html, @directives, @isReadOnly }) ->
+    @renderer = undefined # will be set once the view is attached to a renderer
     @$elem = @$html
     @template = @model.template
     @isAttachedToDom = false
@@ -22,6 +23,12 @@ module.exports = class ComponentView
         .attr(attr.template, @template.identifier)
 
     @render()
+
+
+  setRenderer: (@renderer) ->
+
+  removeRenderer: ->
+    @renderer = undefined
 
 
   render: (mode) ->

--- a/src/rendering/component_view.coffee
+++ b/src/rendering/component_view.coffee
@@ -15,6 +15,11 @@ module.exports = class ComponentView
     @isAttachedToDom = false
     @wasAttachedToDom = $.Callbacks();
 
+    @decorateMarkup()
+    @render()
+
+
+  decorateMarkup: ->
     unless @isReadOnly
       # add attributes and references to the html
       @$html

--- a/src/rendering/component_view.coffee
+++ b/src/rendering/component_view.coffee
@@ -27,6 +27,13 @@ module.exports = class ComponentView
         .addClass(css.component)
         .attr(attr.template, @template.identifier)
 
+
+  recreateHtml: ->
+    @isAttachedToDom = false
+    { @$elem, @directives } = @model.template.createViewHtml(@model)
+    @$html = @$elem
+
+    @decorateMarkup()
     @render()
 
 

--- a/src/rendering/component_view.coffee
+++ b/src/rendering/component_view.coffee
@@ -52,6 +52,9 @@ module.exports = class ComponentView
     @render()
 
 
+  # Remove, recreate and reinsert the html of this view.
+  refresh: ->
+    @renderer.refreshComponent(@model)
 
 
   render: (mode) ->

--- a/src/rendering/component_view.coffee
+++ b/src/rendering/component_view.coffee
@@ -28,6 +28,21 @@ module.exports = class ComponentView
         .attr(attr.template, @template.identifier)
 
 
+  # Renderer
+  # --------
+
+  setRenderer: (renderer) ->
+    @renderer = renderer
+
+
+  removeRenderer: ->
+    @renderer = undefined
+
+
+  viewForModel: (model) ->
+    @renderer?.getComponentViewById(model.id) if model?
+
+
   recreateHtml: ->
     @isAttachedToDom = false
     { @$elem, @directives } = @model.template.createViewHtml(@model)
@@ -37,10 +52,6 @@ module.exports = class ComponentView
     @render()
 
 
-  setRenderer: (@renderer) ->
-
-  removeRenderer: ->
-    @renderer = undefined
 
 
   render: (mode) ->
@@ -93,13 +104,8 @@ module.exports = class ComponentView
         config.animations.optionals.hide($(directive.elem))
 
 
-  next: ->
-    @$html.next().data('componentView')
-
-
-  prev: ->
-    @$html.prev().data('componentView')
-
+  # Focus
+  # -----
 
   afterFocused: () ->
     @$html.addClass(css.componentHighlight)
@@ -352,4 +358,32 @@ module.exports = class ComponentView
 
   getOwnerWindow: ->
     @$elem[0].ownerDocument.defaultView
+
+
+  # Iterators and Tree accessors
+  # ----------------------------
+  #
+  # See the end of this file for the generated iterators
+  # ('children', 'descendants', 'parents' etc.).
+
+  next: ->
+    @viewForModel(@model.next)
+
+
+  prev: -> @previous() # alias
+  previous: ->
+    @viewForModel(@model.previous)
+
+
+  parent: ->
+    @viewForModel(@model.getParent())
+
+
+# Generate componentView Iterators
+# --------------------------------
+
+['parents', 'children', 'childrenAndSelf', 'descendants', 'descendantsAndSelf'].forEach (method) ->
+  ComponentView::[method] = (callback) ->
+    @model[method] (model) =>
+      callback( @viewForModel(model) )
 

--- a/src/rendering/dependencies.coffee
+++ b/src/rendering/dependencies.coffee
@@ -22,6 +22,19 @@ module.exports = class Dependencies
 
 
   # Add a dependency
+  #
+  # # @param {Object}
+  #   - type {String} Either 'js' or 'css'
+  #
+  # One of the following needs to be provided:
+  #   - src {String} URL to a javascript or css file
+  #   - code {String} JS or CSS code
+  #
+  # All of the following are optional:
+  #   - basePath {String} Optional. A base path for relative urls.
+  #   - namespace {String} Optional. A Namespace to group dependencies together.
+  #   - name {String} Optional. A name to identify a dependency more easily.
+  #   - component {ComponentModel} The componentModel that is depending on this resource
   add: (obj) ->
     @convertToAbsolutePaths(obj)
     dep = new Dependency(obj)
@@ -163,7 +176,7 @@ module.exports = class Dependencies
         src: entry.src
         code: entry.code
         namespace: entry.namespace
-        name: entry.name
+        library: entry.library
 
       @addDeserialzedObj(obj, entry)
 
@@ -174,7 +187,7 @@ module.exports = class Dependencies
         src: entry.src
         code: entry.code
         namespace: entry.namespace
-        name: entry.name
+        library: entry.library
 
       @addDeserialzedObj(obj, entry)
 

--- a/src/rendering/dependency.coffee
+++ b/src/rendering/dependency.coffee
@@ -11,10 +11,10 @@ module.exports = class Dependency
   #   - code {String} JS or CSS code
   #
   #   All of the following are optional:
-  #   - namespace {String} Optional. A name to identify a dependency more easily.
   #   - namespace {String} Optional. A Namespace to group dependencies together.
+  #   - library {String} Optional. A name to identify and share a library (like jquery) more easily.
   #   - component {ComponentModel} The componentModel that is depending on this resource
-  constructor: ({ @name, @namespace, @src, @code, @type, component }) ->
+  constructor: ({ @type, @src, @code, @namespace, @library, @isExecuteOnly, component }) ->
     assert @src || @code, 'Dependency: No "src" or "code" param provided'
     assert not (@src && @code), 'Dependency: Only provide one of "src" or "code" params'
     assert @type, "Dependency: Param type must be specified"
@@ -70,9 +70,11 @@ module.exports = class Dependency
 
 
   serialize: ->
+    assert(not @isExecuteOnly, 'engine//dependency.coffee: Cannot serialize a temporary dependency')
+
     obj = {}
 
-    for key in ['src', 'code', 'inline', 'name', 'namespace']
+    for key in ['src', 'code', 'inline', 'library', 'namespace']
       obj[key] = this[key] if this[key]?
 
     for componentId of @components

--- a/src/rendering/renderer.coffee
+++ b/src/rendering/renderer.coffee
@@ -90,9 +90,10 @@ module.exports = class Renderer
     @insertComponent(model)
 
 
-  componentRemoved: (model) ->
-    @removeComponentFromDom(model)
-    @deleteCachedComponentView(model)
+  componentRemoved: (component) ->
+    component.descendantsAndSelf (model) =>
+      @removeComponentFromDom(model)
+      @deleteCachedComponentView(model)
 
 
   componentMoved: (model) ->

--- a/src/rendering/renderer.coffee
+++ b/src/rendering/renderer.coffee
@@ -116,10 +116,15 @@ module.exports = class Renderer
 
 
   getOrCreateComponentView: (model) ->
-    @componentViews[model.id] ||= model.createView(@renderingContainer.isReadOnly)
+    return view if view = @componentViews[model.id]
+
+    view = model.createView(@renderingContainer.isReadOnly)
+    view.setRenderer(this)
+    @componentViews[model.id] = view
 
 
   deleteCachedComponentView: (model) ->
+    @componentViews[model.id]?.removeRenderer()
     delete @componentViews[model.id]
 
 

--- a/src/rendering/renderer.coffee
+++ b/src/rendering/renderer.coffee
@@ -146,6 +146,18 @@ module.exports = class Renderer
     @render()
 
 
+  # Recreate the html of a component and its descendants
+  refreshComponent: (component) ->
+    view = @getComponentViewById(component.id)
+
+    view.descendantsAndSelf (view) =>
+      @removeComponentFromDom(view.model)
+      view.recreateHtml()
+
+    @insertComponent(component)
+    @renderingContainer.componentViewWasRefreshed.fire(view)
+
+
   insertComponent: (model) ->
     return if @isComponentAttached(model) || @excludedComponentIds[model.id] == true
 

--- a/src/rendering_container/js_loader.coffee
+++ b/src/rendering_container/js_loader.coffee
@@ -41,7 +41,7 @@ module.exports = class JsLoader
   # Inline Script
   # -------------
 
-  loadInlineScript: (codeBlock, callback = ->) ->
+  loadInlineScript: (codeBlock, preventRepeatedExecution, callback = ->) ->
     codeBlock = @prepareInlineCode(codeBlock)
     return callback() if @isInlineBlockLoaded(codeBlock)
 
@@ -50,7 +50,7 @@ module.exports = class JsLoader
     script = doc.createElement('script');
     script.innerHTML = codeBlock;
     doc.body.appendChild(script);
-    @loadedScripts.push(codeBlock)
+    @loadedScripts.push(codeBlock) if preventRepeatedExecution
 
     callback()
 

--- a/src/rendering_container/page.coffee
+++ b/src/rendering_container/page.coffee
@@ -14,6 +14,7 @@ module.exports = class Page extends RenderingContainer
     @renderNode = if renderNode?.jquery then renderNode[0] else renderNode
     @setWindow(hostWindow)
     @renderNode ?= $(".#{ config.css.section }", @$body)
+    @componentViewWasRefreshed = $.Callbacks() # (componentView) ->
 
     super()
 

--- a/src/rendering_container/page.coffee
+++ b/src/rendering_container/page.coffee
@@ -35,15 +35,24 @@ module.exports = class Page extends RenderingContainer
   loadAssets: =>
     # First load design dependencies
     if @design?
-      @assets.loadDependencies(@design.dependencies, @readySemaphore.wait())
+      deps = @design.dependencies
+      @assets.loadDependencies(deps.js, deps.css, @readySemaphore.wait())
 
     # Then load document specific dependencies
     if @documentDependencies?
-      @assets.loadDependencies(@documentDependencies, @readySemaphore.wait())
+      deps = @documentDependencies
+      @assets.loadDependencies(deps.js, deps.css, @readySemaphore.wait())
 
       # listen for new dependencies
-      @documentDependencies.dependencyAdded.add (dependency) =>
+      @documentDependencies.dependenciesAdded.add (jsDependencies, cssDependencies) =>
+        @assets.loadDependencies(jsDependencies, cssDependencies, ->)
+
+      # listen for dependencies to execute once
+      @documentDependencies.dependencyToExecute.add (dependency) =>
         @assets.loadDependency(dependency)
+
+      @documentDependencies.codeToExecute.add (callback) =>
+        callback(@window)
 
 
   setWindow: (hostWindow) ->

--- a/src/template/template.coffee
+++ b/src/template/template.coffee
@@ -50,15 +50,21 @@ module.exports = class Template
 
 
   createView: (componentModel, isReadOnly) ->
+    { $elem, directives } = @createViewHtml()
     componentModel ||= @createModel()
-    $elem = @$template.clone()
-    directives = @linkDirectives($elem[0])
 
     componentView = new ComponentView
       model: componentModel
       $html: $elem
       directives: directives
       isReadOnly: isReadOnly
+
+
+  createViewHtml: ->
+    $elem = @$template.clone()
+    directives = @linkDirectives($elem[0])
+
+    { $elem, directives }
 
 
   pruneHtml: (html) ->

--- a/test/specs/rendering/component_view_spec.coffee
+++ b/test/specs/rendering/component_view_spec.coffee
@@ -50,7 +50,6 @@ describe 'component_view:', ->
 
     beforeEach ->
       @title = test.getComponent('title')
-      @title.setStyle('color', 'color--blue')
       @$expected = $ """
         <h1 #{ test.editableAttr }="title"
             class="#{ css.editable } #{ css.component }"
@@ -59,18 +58,26 @@ describe 'component_view:', ->
         </h1>"""
 
 
+    describe 'recreateHtml()', ->
 
+      it 'resets changes made in the views html', ->
+        view = @title.createView()
+        view.$html.addClass('test-class')
+        view.recreateHtml()
+        expect(view.$html).to.have.html(@$expected)
 
 
     describe 'updates the style', ->
 
       it 'sets "color" style to "color--blue"', ->
+        @title.setStyle('color', 'color--blue')
         @$expected.addClass('color--blue')
         componentView = @title.createView()
         expect(componentView.$html).to.have.html(@$expected)
 
 
       it 'changes "color" style from "color--blue" to "color--red"', ->
+        @title.setStyle('color', 'color--blue')
         @$expected.addClass('color--red')
         componentView = @title.createView()
         componentView.setStyle('color', 'color--red')

--- a/test/specs/rendering/component_view_spec.coffee
+++ b/test/specs/rendering/component_view_spec.coffee
@@ -309,3 +309,51 @@ describe 'component_view:', ->
       @view.render()
       expect(@view.$html).to.have.attr('src', base64Image)
 
+
+  describe 'with multiple components', ->
+
+    beforeEach (done) ->
+      { @renderer, @componentTree } = test.get('page', 'renderer')
+      @componentTree.fromData content: [
+        component: 'title'
+        content: { 'title': 'A Title' }
+      ,
+        component: 'subtitle'
+        content: { 'title': 'A Subtitle' }
+      ,
+        component: 'container'
+        containers:
+          'default': [
+            component: 'text'
+            content: { 'text': 'some text' }
+          ]
+      ], undefined, false
+      @componentTree.setMainView({ @renderer })
+      @renderer.ready(done)
+
+
+    describe 'next() and prev()', ->
+
+      it 'return the correct views', ->
+        titleView = @componentTree.find('title').first.getMainView()
+        subtitleView = @componentTree.find('subtitle').first.getMainView()
+        containerView = @componentTree.find('container').first.getMainView()
+
+        expect(subtitleView.next()).to.equal(containerView)
+        expect(subtitleView.prev()).to.equal(titleView)
+
+
+    describe 'descendantsAndSelf()', ->
+
+      it 'iterates over children', ->
+        containerView = @componentTree.find('container').first.getMainView()
+        textView = @componentTree.find('text').first.getMainView()
+        views = []
+
+        containerView.descendantsAndSelf (view) ->
+          views.push(view)
+
+        expect(views.length).to.equal(2)
+        expect(views[0]).to.equal(containerView)
+        expect(views[1]).to.equal(textView)
+

--- a/test/specs/rendering/component_view_spec.coffee
+++ b/test/specs/rendering/component_view_spec.coffee
@@ -313,7 +313,7 @@ describe 'component_view:', ->
   describe 'with multiple components', ->
 
     beforeEach (done) ->
-      { @renderer, @componentTree } = test.get('page', 'renderer')
+      { @renderer, @componentTree, @page } = test.get('page', 'renderer')
       @componentTree.fromData content: [
         component: 'title'
         content: { 'title': 'A Title' }
@@ -356,4 +356,34 @@ describe 'component_view:', ->
         expect(views.length).to.equal(2)
         expect(views[0]).to.equal(containerView)
         expect(views[1]).to.equal(textView)
+
+
+    describe 'refresh()', ->
+
+      it 'recreates the html of the view (with descendants)', ->
+        containerView = @componentTree.find('container').first.getMainView()
+        containerView.$html.find('p').addClass('some-test')
+        containerView.refresh()
+        expect(containerView.$html[0].outerHTML).to.have.html '
+          <div class="container">
+            <div><p>some text</p></div>
+          </div>
+        '
+
+
+      it 'updates the html of the renderer', ->
+        containerView = @componentTree.find('container').first.getMainView()
+        containerView.$html.find('p').addClass('some-test')
+        containerView.refresh()
+        expect(@page.renderNode).to.have.html '
+          <section>
+            <h1>A Title</h1>
+            <h2>A Subtitle</h2>
+            <div class="container">
+              <div>
+                <p>some text</p>
+              </div>
+            </div>
+          </section>
+        '
 

--- a/test/specs/rendering/component_view_spec.coffee
+++ b/test/specs/rendering/component_view_spec.coffee
@@ -6,7 +6,7 @@ attr = test.config.attr
 
 describe 'component_view:', ->
 
-  describe 'title', ->
+  describe 'title view', ->
 
     beforeEach ->
       @view = test.getTemplate('title').createView()
@@ -46,254 +46,259 @@ describe 'component_view:', ->
       expect( @view.get('title') ).to.equal('Games Galore')
 
 
-describe 'ComponentView title set style', ->
+  describe 'of a title component', ->
 
-  beforeEach ->
-    @title = test.getComponent('title')
-    @title.setStyle('color', 'color--blue')
-    @$expected = $ """
-      <h1 #{ test.editableAttr }="title"
-          class="#{ css.editable } #{ css.component }"
-          #{ attr.template }="test.title"
-          #{ attr.placeholder }="#{ @title.template.defaults['title'] }">
-      </h1>"""
-
-  it 'sets "color" style to "color--blue"', ->
-    @$expected.addClass('color--blue')
-    componentView = @title.template.createView(@title)
-    expect(componentView.$html).to.have.html(@$expected)
-
-
-  it 'changes "color" style from "color--blue" to "color--red"', ->
-    @$expected.addClass('color--red')
-    componentView = @title.template.createView(@title)
-    componentView.setStyle('color', 'color--red')
-    expect(componentView.$html).to.have.html(@$expected)
-
-
-describe 'ComponentView hero', ->
-
-  beforeEach ->
-    component = test.getComponent('hero')
-    component.set('title', 'Humble Bundle 2')
-    component.set('tagline', 'Get it now!')
-    template = test.getTemplate('hero')
-    @view = template.createView(component)
-    @expected = $ """
-      <div  class="#{ css.component }"
-            #{ attr.template }="test.hero">
+    beforeEach ->
+      @title = test.getComponent('title')
+      @title.setStyle('color', 'color--blue')
+      @$expected = $ """
         <h1 #{ test.editableAttr }="title"
-            class="#{ css.editable } #{ css.noPlaceholder }"
-            #{ attr.placeholder }="#{ @view.template.defaults['title'] }">Humble Bundle 2</h1>
-        <p  #{ test.editableAttr }="tagline"
-            class="#{ css.editable } #{ css.noPlaceholder }"
-            #{ attr.placeholder }="#{ @view.template.defaults['tagline'] }">Get it now!</p>
-      </div>"""
+            class="#{ css.editable } #{ css.component }"
+            #{ attr.template }="test.title"
+            #{ attr.placeholder }="#{ @title.template.defaults['title'] }">
+        </h1>"""
 
 
-  it 'renders component content on creation', ->
-    expect(@view.$html).to.have.html(@expected)
 
 
-  it 'sets "extra-space"', ->
-    @expected.addClass('extra-space')
-    @view.setStyle('extra-space', 'extra-space')
-    expect(@view.$html).to.have.html(@expected)
+
+    describe 'updates the style', ->
+
+      it 'sets "color" style to "color--blue"', ->
+        @$expected.addClass('color--blue')
+        componentView = @title.createView()
+        expect(componentView.$html).to.have.html(@$expected)
 
 
-  it 'resets "extra-space"', ->
-    @view.setStyle('extra-space', 'extra-space')
-    @view.setStyle('extra-space', '')
-    expect(@view.$html).to.have.html(@expected)
+      it 'changes "color" style from "color--blue" to "color--red"', ->
+        @$expected.addClass('color--red')
+        componentView = @title.createView()
+        componentView.setStyle('color', 'color--red')
+        expect(componentView.$html).to.have.html(@$expected)
 
 
-  it 'set(directiveName) does only update the passed directive', ->
-    @view.model.set('title', 'bla')
-    spy = sinon.spy(@view, 'set')
-    @view.updateContent('title')
-    expect(spy.callCount).to.equal(1)
-    expect(spy.firstCall.args[0]).to.equal('title')
-
-
-  describe 'empty optional', ->
+  describe 'of a hero component', ->
 
     beforeEach ->
-      @view.model.set('tagline', undefined)
-      @view.render()
-      @expected.find('p').hide().html('')
-      @expected.find('p').removeClass(css.noPlaceholder)
+      component = test.getComponent('hero')
+      component.set('title', 'Humble Bundle 2')
+      component.set('tagline', 'Get it now!')
+      @view = component.createView()
+      @expected = $ """
+        <div  class="#{ css.component }"
+              #{ attr.template }="test.hero">
+          <h1 #{ test.editableAttr }="title"
+              class="#{ css.editable } #{ css.noPlaceholder }"
+              #{ attr.placeholder }="#{ @view.template.defaults['title'] }">Humble Bundle 2</h1>
+          <p  #{ test.editableAttr }="tagline"
+              class="#{ css.editable } #{ css.noPlaceholder }"
+              #{ attr.placeholder }="#{ @view.template.defaults['tagline'] }">Get it now!</p>
+        </div>"""
 
 
-    it 'is hidden by default', ->
+    it 'renders component content on creation', ->
       expect(@view.$html).to.have.html(@expected)
 
 
-describe 'ComponentView image', ->
-
-  beforeEach ->
-    @component = test.getComponent('image')
-
-
-  describe 'with the default image service', ->
-
-    expectSrc = (view, src) ->
-      expect(view.$html).to.have.html """
-        <img src="#{ src }"
-          #{ test.imageAttr }="image"
-          class="#{ css.component }"
-          #{ attr.template }="test.image">"""
-
-
-    it 'sets the src', ->
-      @component.set('image', 'http://images.com/1')
-      @view = @component.createView()
-      @view.updateContent('image')
-      expectSrc(@view, 'http://images.com/1')
-
-
-  describe 'with the resrc.it image service', ->
-
-    it 'sets the data-src attribute', ->
-      @view = @component.createView()
-      @view.model.directives.get('image').setImageService('resrc.it')
-      @component.set('image', 'http://images.com/1')
-      @view.updateContent('image')
-      expect(@view.$html).to.have.html """
-        <img
-          src=""
-          data-src="https://app.resrc.it/O=75/http://images.com/1"
-          class="#{ css.component } resrc"
-          #{ test.imageAttr }="image"
-          #{ attr.template }="test.image">
-          """
-
-  describe 'delayed placeholder insertion', ->
-
-    beforeEach ->
-      @view = @component.createView()
-      @view.set('image', undefined)
-
-
-    it 'does not insert placeholders before view is attached', ->
-      expect(@view.$html).to.have.html """
-        <img src=""
-          #{ test.imageAttr }="image"
-          class="#{ css.component }"
-          #{ attr.template }="test.image">"""
-
-
-    it 'inserts placeholder when view is attached', ->
-      placeholderUrl = test.config.imagePlaceholder
-      @view.wasAttachedToDom.fireWith(@view.$html)
-
-      expect(@view.$html).to.have.html """
-        <img src="#{ placeholderUrl }"
-          #{ test.imageAttr }="image"
-          class="#{ css.component } doc-image-empty"
-          #{ attr.template }="test.image">"""
-
-
-    it 'does not re-insert placeholders if value is set later on', ->
-      imageUrl = 'http://www.bla.com'
-      @component.set('image', imageUrl)
-      @view.updateContent('image')
-      @view.wasAttachedToDom.fireWith(@view.$html)
-
-      expect(@view.$html).to.have.html """
-        <img src="#{ imageUrl }"
-          #{ test.imageAttr }="image"
-          class="#{ css.component }"
-          #{ attr.template }="test.image">"""
-
-
-    it 'remove the empty image css class when the image is set', ->
-      imageUrl = 'http://www.bla.com'
-      @view.wasAttachedToDom.fireWith(@view.$html)
-      @component.set('image', imageUrl)
-      @view.updateContent('image')
-
-      expect(@view.$html).to.have.html """
-        <img src="#{ imageUrl }"
-          #{ test.imageAttr }="image"
-          class="#{ css.component }"
-          #{ attr.template }="test.image">"""
-
-
-describe 'ComponentView background image', ->
-
-  beforeEach ->
-    @component = test.getComponent('background-image')
-
-
-  describe 'with the default image service', ->
-
-    it 'sets the background-image in the style attribute', ->
-      @component.set('image', 'http://images.com/1')
-      @view = @component.createView()
-      @view.updateContent('image')
-      expect(@view.$html).to.have.html """
-        <div
-          style="background-image: url(http://images.com/1);"
-          #{ test.imageAttr }="image"
-          class="#{ css.component }"
-          #{ attr.template }="test.background-image">"""
-
-
-describe 'ComponentView html', ->
-
-  beforeEach ->
-    @component = test.getComponent('html')
-    @component.set('source', '<section>test</section>')
-    @view = @component.createView()
-    # There is additional code by the interaction blocker element in there
-    # which is not nice but hopefully works out just fine.
-    @expected = $ """
-      <div class="#{ css.component }"
-        #{ attr.template }="test.html"
-        #{ test.htmlAttr }="source"
-        style="position: relative; ">
-        <section>test</section>
-        <div class="doc-interaction-blocker" style="position: absolute; top: 0; bottom: 0; left: 0; right: 0;"></div>
-      </div>
-      """
-
-
-  describe 'set("source", value)', ->
-
-    it 'adds the html to the component', ->
+    it 'sets "extra-space"', ->
+      @expected.addClass('extra-space')
+      @view.setStyle('extra-space', 'extra-space')
       expect(@view.$html).to.have.html(@expected)
 
 
-    describe 'when clearing an existing value', ->
-      it 'inserts the default value', ->
-        @component.set('source', undefined)
+    it 'resets "extra-space"', ->
+      @view.setStyle('extra-space', 'extra-space')
+      @view.setStyle('extra-space', '')
+      expect(@view.$html).to.have.html(@expected)
+
+
+    it 'set(directiveName) does only update the passed directive', ->
+      @view.model.set('title', 'bla')
+      spy = sinon.spy(@view, 'set')
+      @view.updateContent('title')
+      expect(spy.callCount).to.equal(1)
+      expect(spy.firstCall.args[0]).to.equal('title')
+
+
+    describe 'empty optional', ->
+
+      beforeEach ->
+        @view.model.set('tagline', undefined)
         @view.render()
-        @expected.html(@component.template.defaults['source'])
+        @expected.find('p').hide().html('')
+        @expected.find('p').removeClass(css.noPlaceholder)
+
+
+      it 'is hidden by default', ->
         expect(@view.$html).to.have.html(@expected)
 
 
-describe 'using volatile values', ->
+  describe 'of an image component', ->
 
-  beforeEach ->
-    @component = test.getComponent('image')
-    @component.directives.get('image').setBase64Image(base64Image)
-    @view = @component.createView()
+    beforeEach ->
+      @component = test.getComponent('image')
 
 
-  it 'uses a temporary base64 value if there is no image set', ->
-    @view.render()
-    expect(@view.$html).to.have.attr('src', base64Image)
+    describe 'with the default image service', ->
+
+      expectSrc = (view, src) ->
+        expect(view.$html).to.have.html """
+          <img src="#{ src }"
+            #{ test.imageAttr }="image"
+            class="#{ css.component }"
+            #{ attr.template }="test.image">"""
 
 
-  it 'uses the image content if it is set after the temporary base64', ->
-    @component.set('image', 'http://www.lolcats.com/images/u/12/24/lolcatsdotcompromdate.jpg')
-    @view.render()
-    expect(@view.$html).to.have.attr('src', 'http://www.lolcats.com/images/u/12/24/lolcatsdotcompromdate.jpg')
+      it 'sets the src', ->
+        @component.set('image', 'http://images.com/1')
+        @view = @component.createView()
+        @view.updateContent('image')
+        expectSrc(@view, 'http://images.com/1')
 
 
-  it 'prefers a temporary value if it is set after the persisted url content', ->
-    @component.set('image', 'http://www.lolcats.com/images/u/12/24/lolcatsdotcompromdate.jpg')
-    @component.directives.get('image').setBase64Image(base64Image)
-    @view.render()
-    expect(@view.$html).to.have.attr('src', base64Image)
+    describe 'with the resrc.it image service', ->
+
+      it 'sets the data-src attribute', ->
+        @view = @component.createView()
+        @view.model.directives.get('image').setImageService('resrc.it')
+        @component.set('image', 'http://images.com/1')
+        @view.updateContent('image')
+        expect(@view.$html).to.have.html """
+          <img
+            src=""
+            data-src="https://app.resrc.it/O=75/http://images.com/1"
+            class="#{ css.component } resrc"
+            #{ test.imageAttr }="image"
+            #{ attr.template }="test.image">
+            """
+
+    describe 'delayed placeholder insertion', ->
+
+      beforeEach ->
+        @view = @component.createView()
+        @view.set('image', undefined)
+
+
+      it 'does not insert placeholders before view is attached', ->
+        expect(@view.$html).to.have.html """
+          <img src=""
+            #{ test.imageAttr }="image"
+            class="#{ css.component }"
+            #{ attr.template }="test.image">"""
+
+
+      it 'inserts placeholder when view is attached', ->
+        placeholderUrl = test.config.imagePlaceholder
+        @view.wasAttachedToDom.fireWith(@view.$html)
+
+        expect(@view.$html).to.have.html """
+          <img src="#{ placeholderUrl }"
+            #{ test.imageAttr }="image"
+            class="#{ css.component } doc-image-empty"
+            #{ attr.template }="test.image">"""
+
+
+      it 'does not re-insert placeholders if value is set later on', ->
+        imageUrl = 'http://www.bla.com'
+        @component.set('image', imageUrl)
+        @view.updateContent('image')
+        @view.wasAttachedToDom.fireWith(@view.$html)
+
+        expect(@view.$html).to.have.html """
+          <img src="#{ imageUrl }"
+            #{ test.imageAttr }="image"
+            class="#{ css.component }"
+            #{ attr.template }="test.image">"""
+
+
+      it 'remove the empty image css class when the image is set', ->
+        imageUrl = 'http://www.bla.com'
+        @view.wasAttachedToDom.fireWith(@view.$html)
+        @component.set('image', imageUrl)
+        @view.updateContent('image')
+
+        expect(@view.$html).to.have.html """
+          <img src="#{ imageUrl }"
+            #{ test.imageAttr }="image"
+            class="#{ css.component }"
+            #{ attr.template }="test.image">"""
+
+
+  describe 'of a component with a background image', ->
+
+    beforeEach ->
+      @component = test.getComponent('background-image')
+
+
+    describe 'with the default image service', ->
+
+      it 'sets the background-image in the style attribute', ->
+        @component.set('image', 'http://images.com/1')
+        @view = @component.createView()
+        @view.updateContent('image')
+        expect(@view.$html).to.have.html """
+          <div
+            style="background-image: url(http://images.com/1);"
+            #{ test.imageAttr }="image"
+            class="#{ css.component }"
+            #{ attr.template }="test.background-image">"""
+
+
+  describe 'ComponentView html', ->
+
+    beforeEach ->
+      @component = test.getComponent('html')
+      @component.set('source', '<section>test</section>')
+      @view = @component.createView()
+      # There is additional code by the interaction blocker element in there
+      # which is not nice but hopefully works out just fine.
+      @expected = $ """
+        <div class="#{ css.component }"
+          #{ attr.template }="test.html"
+          #{ test.htmlAttr }="source"
+          style="position: relative; ">
+          <section>test</section>
+          <div class="doc-interaction-blocker" style="position: absolute; top: 0; bottom: 0; left: 0; right: 0;"></div>
+        </div>
+        """
+
+
+    describe 'set("source", value)', ->
+
+      it 'adds the html to the component', ->
+        expect(@view.$html).to.have.html(@expected)
+
+
+      describe 'when clearing an existing value', ->
+        it 'inserts the default value', ->
+          @component.set('source', undefined)
+          @view.render()
+          @expected.html(@component.template.defaults['source'])
+          expect(@view.$html).to.have.html(@expected)
+
+
+  describe 'using volatile values', ->
+
+    beforeEach ->
+      @component = test.getComponent('image')
+      @component.directives.get('image').setBase64Image(base64Image)
+      @view = @component.createView()
+
+
+    it 'uses a temporary base64 value if there is no image set', ->
+      @view.render()
+      expect(@view.$html).to.have.attr('src', base64Image)
+
+
+    it 'uses the image content if it is set after the temporary base64', ->
+      @component.set('image', 'http://www.lolcats.com/images/u/12/24/lolcatsdotcompromdate.jpg')
+      @view.render()
+      expect(@view.$html).to.have.attr('src', 'http://www.lolcats.com/images/u/12/24/lolcatsdotcompromdate.jpg')
+
+
+    it 'prefers a temporary value if it is set after the persisted url content', ->
+      @component.set('image', 'http://www.lolcats.com/images/u/12/24/lolcatsdotcompromdate.jpg')
+      @component.directives.get('image').setBase64Image(base64Image)
+      @view.render()
+      expect(@view.$html).to.have.attr('src', base64Image)
 

--- a/test/specs/rendering/dependencies_spec.coffee
+++ b/test/specs/rendering/dependencies_spec.coffee
@@ -37,7 +37,7 @@ describe 'dependencies:', ->
       @componentTree.append(component)
 
       @dependencies.addJs
-        name: 'twitter'
+        library: 'twitter-widgets'
         namespace: 'embeds.twitter'
         src: 'https://platform.twitter.com/widgets.js'
         component: component
@@ -45,7 +45,7 @@ describe 'dependencies:', ->
       expect(@dependencies.serialize().js).to.deep.equal [
         {
           src: 'https://platform.twitter.com/widgets.js'
-          name: 'twitter'
+          library: 'twitter-widgets'
           namespace: 'embeds.twitter'
           componentIds: [ component.id ]
         }
@@ -100,12 +100,12 @@ describe 'dependencies:', ->
     it 'deserializes the dependencies', ->
       data =
         js: [
-          { src: 'https://platform.twitter.com/widgets.js', name: 'twitter' }
-          { code: 'alert("hey")', name: 'custom101', inline: true, namespace: 'embed.test' }
+          { src: 'https://platform.twitter.com/widgets.js', library: 'twitter-widgets' }
+          { code: 'alert("hey")', inline: true, namespace: 'embed.test' }
         ]
         css: [
-          { src: 'http://restyle.it', name: 'restyle', namespace: 'embed.test' }
-          { code: '* { background: red !important; }', name: 'important styles', inline: true }
+          { src: 'http://restyle.it', library: 'restyle', namespace: 'embed.test' }
+          { code: '* { background: red !important; }', inline: true }
         ]
       @dependencies.deserialize(data)
       expect(@dependencies.serialize()).to.deep.equal(data)
@@ -117,7 +117,7 @@ describe 'dependencies:', ->
 
       data =
         js: [
-          { code: 'alert("hey")', name: 'custom101', inline: true, componentIds: [ @component.id ] }
+          { code: 'alert("hey")', inline: true, componentIds: [ @component.id ] }
         ]
 
       @dependencies.deserialize(data)
@@ -127,7 +127,7 @@ describe 'dependencies:', ->
     it 'discards dependencies with non-existing components', ->
       data =
         js: [
-          { code: 'alert("hey")', name: 'custom101', inline: true, componentIds: ['xxx'] }
+          { code: 'alert("hey")', inline: true, componentIds: ['xxx'] }
         ]
       @dependencies.deserialize(data)
       expect(@dependencies.serialize()).to.deep.equal({})
@@ -167,8 +167,6 @@ describe 'dependencies:', ->
         '/my/custom/path/to/the/design.css',
         '/my/custom/path/to/the/design.css'
       )
-
-
 
 
   describe 'namespaces', ->


### PR DESCRIPTION
- recreate the html of views (to be able to cope with js libraries which change the html structure of components)
- fix bugs with child components in `Renderer`
- store a plugin reference in `ComponentModel`