### PR TITLE
Image directive mimetype

### DIFF
--- a/src/component_tree/field_extractor.coffee
+++ b/src/component_tree/field_extractor.coffee
@@ -195,6 +195,7 @@ module.exports = class FieldExtractor
       url: imageDirective.getImageUrl()
       width: imageDirective.getOriginalImageDimensions()?.width
       height: imageDirective.getOriginalImageDimensions()?.height
+      mimeType: imageDirective.getMimeType()
       imageService: imageDirective.getImageServiceName()
 
 

--- a/src/component_tree/image_directive.coffee
+++ b/src/component_tree/image_directive.coffee
@@ -91,6 +91,16 @@ module.exports = class ImageDirective extends ComponentDirective
     height: content?.height
 
 
+  setMimeType: (mimeType) ->
+    content = @component.content[@name]
+    content.mimeType = mimeType
+
+
+  getMimeType: ->
+    content = @component.content[@name]
+    content.mimeType
+
+
   resetCrop: ->
     currentValue = @component.content[@name]
     if currentValue?

--- a/src/component_tree/image_directive.coffee
+++ b/src/component_tree/image_directive.coffee
@@ -93,17 +93,13 @@ module.exports = class ImageDirective extends ComponentDirective
 
   setMimeType: (mimeType) ->
     @component.content[@name] ?= {}
-
     content = @component.content[@name]
     content.mimeType = mimeType
 
 
   getMimeType: ->
     content = @component.content[@name]
-    if content
-      content.mimeType
-    else
-      undefined
+    content?.mimeType
 
 
   resetCrop: ->

--- a/src/component_tree/image_directive.coffee
+++ b/src/component_tree/image_directive.coffee
@@ -92,13 +92,18 @@ module.exports = class ImageDirective extends ComponentDirective
 
 
   setMimeType: (mimeType) ->
+    @component.content[@name] ?= {}
+
     content = @component.content[@name]
     content.mimeType = mimeType
 
 
   getMimeType: ->
     content = @component.content[@name]
-    content.mimeType
+    if content
+      content.mimeType
+    else
+      undefined
 
 
   resetCrop: ->

--- a/test/specs/component_tree/component_directive_spec.coffee
+++ b/test/specs/component_tree/component_directive_spec.coffee
@@ -20,6 +20,17 @@ describe 'component_directive:', ->
         expect(@imgDirective.getImageUrl()).to.equal(undefined)
 
 
+    describe 'getMimeType()', ->
+
+      it 'returns undefined for an empty image', ->
+        expect(@imgDirective.getMimeType()).to.equal(undefined)
+
+
+      it 'returns set value', ->
+        @imgDirective.setMimeType('image/png')
+        expect(@imgDirective.getMimeType()).to.equal('image/png')
+
+
     describe 'setImageService()', ->
 
       it 'sets resrc.it as image service', ->


### PR DESCRIPTION
To use image directive with some internal services mime-type field is needed.