### PR TITLE
Field extractor with previously empty components

### DIFF
--- a/src/component_tree/component_tree.coffee
+++ b/src/component_tree/component_tree.coffee
@@ -113,14 +113,22 @@ module.exports = class ComponentTree
 
   # Get all components flattened into an array
   getAllComponents: ->
-    components = []
-    @each (c) -> components.push(c)
-    components
+
+    return @_componentsArrayCache if @_componentsArrayCache
+
+    @_componentsArrayCache = []
+    @each (c) => @_componentsArrayCache.push(c)
+    @_componentsArrayCache
 
 
   # Get the nth component with zero based index
   eq: (index) ->
     @getAllComponents()[index]
+
+
+  # Get the index of a component when traversing the tree
+  indexOf: (component) ->
+    @getAllComponents().indexOf(component)
 
 
   # Traverse all containers and components
@@ -217,9 +225,11 @@ module.exports = class ComponentTree
   # These functions should only be called by componentContainers
 
   attachingComponent: (component, attachComponentFunc) ->
+
     if component.componentTree == this
       # move component
       attachComponentFunc()
+      delete @_componentsArrayCache
       @fireEvent('componentMoved', component)
     else
       if component.componentTree?
@@ -230,6 +240,7 @@ module.exports = class ComponentTree
         @componentById[descendant.id] = component
 
       attachComponentFunc()
+      delete @_componentsArrayCache
       @fireEvent('componentAdded', component)
 
 
@@ -247,6 +258,7 @@ module.exports = class ComponentTree
       @componentById[descendant.id] = undefined
 
     detachComponentFunc()
+    delete @_componentsArrayCache
     @fireEvent('componentRemoved', component)
 
 

--- a/src/component_tree/field_extractor.coffee
+++ b/src/component_tree/field_extractor.coffee
@@ -149,6 +149,17 @@ module.exports = class FieldExtractor
       else if (fieldWasEmpty || fieldWasFilledFromThisComponent) and !_.isEqual(@fields[fieldName], field)
         @fields[fieldName] = changedFields[fieldName] = field
 
+      else if !fieldIsEmpty && !fieldWasFilledFromThisComponent
+        previousComponentIndex = componentModel.componentTree.indexOf(
+          @fields[fieldName].component
+        )
+        currentComponentIndex = componentModel.componentTree.indexOf(
+          componentModel
+        )
+
+        if previousComponentIndex > currentComponentIndex
+          @fields[fieldName] = changedFields[fieldName] = field
+
     if fieldsThatNeedFullExtraction.length
       _(@extractFields(fieldsThatNeedFullExtraction)).forEach (field, fieldName) =>
         @fields[fieldName] = changedFields[fieldName] = field

--- a/test/specs/component_tree/field_extractor_spec.coffee
+++ b/test/specs/component_tree/field_extractor_spec.coffee
@@ -124,6 +124,19 @@ describe 'Field Extractor', ->
       expect(@fieldsChanged).to.not.have.been.called
 
 
+    it 'fires when a previously empty component is filled', (done) ->
+      testString = 'new hero title'
+      heroComponent = @tree.find('hero').first
+      newHeroComponent = @tree.getComponent('hero')
+      heroComponent.before(newHeroComponent)
+
+      @extractor.fieldsChanged.add (changedFields) ->
+        expect(changedFields.documentTitle.text).to.equal(testString)
+        expect(_(changedFields).size()).to.equal(1)
+        done()
+
+      newHeroComponent.set('title', testString)
+
     it 'fires the fieldsChanged event when removing a component', (done) ->
       @extractor.fieldsChanged.add (changedFields) ->
         expect(changedFields.documentTitle.text).to.equal('Subtitle Title')


### PR DESCRIPTION
The spec (14cc1ef) should provide enough information as to what I am trying to fix.

In order to be able to extract the fields in a performant way, I added a `componentTree.indexOf()` and refactored the `componentTree.eq()` methods.

@peyerluk Feel free to review and merge.