### PR TITLE
use https instead of ssh for livingdocs-design-boilerplate

### DIFF
--- a/bower.json
+++ b/bower.json
@@ -13,6 +13,6 @@
     "editable": "0.5.1"
   },
   "devDependencies": {
-    "livingdocs-design-boilerplate": "git@github.com:upfrontIO/livingdocs-design-boilerplate#v0.3.0"
+    "livingdocs-design-boilerplate": "https://github.com/upfrontIO/livingdocs-design-boilerplate.git#v0.3.0"
   }
 }


### PR DESCRIPTION
Use https instead of ssh, because it's more likely that https isn't block in corporate networks.