### PR TITLE
Simplify wrapper logic in livingdoc.createView()

### DIFF
--- a/public/index.html
+++ b/public/index.html
@@ -89,7 +89,8 @@
                 }
               ],
               design: {
-                name: 'boilerplate'
+                name: 'boilerplate',
+                version: '0.3.0'
               }
             }
           }

--- a/public/index.html
+++ b/public/index.html
@@ -14,16 +14,8 @@
   <body>
     <!-- <div class="container-fluid"></div> -->
     <nav class="doc-toolbar"></nav>
-    <section class="editor-section">
-      <div class="container-fluid doc-section"></div>
-    </section>
-    <div class="editor-preview">
-
-      <!-- All these child nodes will be transferred into the iframe -->
-      <h3>Preview:</h3>
-      <div class="container-fluid doc-section"></div>
-
-    </div>
+    <section class="editor-section"></section>
+    <div class="editor-preview"></div>
 
     <!-- dependencies of livingdocs-engine -->
     <script src="//code.jquery.com/jquery-2.1.1.js"></script>
@@ -46,8 +38,20 @@
         var livingdoc = doc.new(content);
 
         // Create Views
-        var viewReady = livingdoc.createView({ host: '.editor-section', interactive: true });
-        var previewReady = livingdoc.createView({ host: '.editor-preview' });
+        var wrapper = '<div class="container-fluid doc-section"></div>';
+
+        // Interactive View
+        var viewReady = livingdoc.createView({
+          host: '.editor-section',
+          wrapper: wrapper,
+          interactive: true
+        });
+
+        // Mobile preview
+        var previewReady = livingdoc.createView({
+          host: '.editor-preview',
+          wrapper: wrapper
+        });
 
         // Create Components
         var $toolbar = $('.doc-toolbar');

--- a/src/livingdoc.coffee
+++ b/src/livingdoc.coffee
@@ -102,12 +102,15 @@ module.exports = class Livingdoc extends EventEmitter
   # Example:
   # article.appendTo({ host: '.article', interactive: true, loadResources: false })
   createView: ({ host, interactive, loadResources, wrapper, layoutName, iframe }) ->
-    viewWrapper = @getWrapper({ wrapper, layoutName, host })
+    $host = $(host)
     iframe ?= true
+
+    $host.html('') # empty container
+    viewWrapper = @getWrapper({ wrapper, layoutName })
 
     view = new View
       livingdoc: this
-      parent: $(host)
+      parent: $host
       isInteractive: interactive
       loadResources: loadResources
       wrapper: viewWrapper
@@ -135,31 +138,12 @@ module.exports = class Livingdoc extends EventEmitter
     @componentTree.createComponent.apply(@componentTree, arguments)
 
 
-  getWrapper: ({ wrapper, layoutName, host }) ->
-    return wrapper if wrapper?
-
-    layoutName ?= @layoutName
-    wrapper = @design.getLayout(layoutName)?.wrapper
-    wrapper ?= @extractWrapper(host)
-
-    return wrapper
-
-
-  # A view sometimes has to be wrapped in a container.
-  #
-  # Example:
-  # Here the document is rendered into $('.doc-section')
-  # <div class="iframe-container">
-  #   <section class="container doc-section"></section>
-  # </div>
-  extractWrapper: (parent) ->
-    $parent = $(parent).first()
-    if $parent.find(".#{ config.css.section }").length == 1
-      $wrapper = $($parent.html())
-
-    $parent.html('') # empty container
-
-    return $wrapper
+  getWrapper: ({ wrapper, layoutName }) ->
+    if wrapper?
+      return wrapper
+    else
+      layoutName ?= @layoutName
+      return @design.getLayout(layoutName)?.wrapper
 
 
   addView: (view) ->


### PR DESCRIPTION
The `public/index.html` file was broken. It made use of the automatic wrapper extraction feature. But recent changes with layouts in designs broke this. The layout takes precedence if no `layoutName` was passed to `createView()` and the wrapper extraction never took place.

Instead of fixing the problem I opted to remove the automatic wrapper extraction altogether.